### PR TITLE
Fix for generated action triggers.

### DIFF
--- a/src/org/dmd/dmc/DmcObject.java
+++ b/src/org/dmd/dmc/DmcObject.java
@@ -777,6 +777,23 @@ abstract public class DmcObject implements Serializable {
 	}
 	
 	/**
+	 * Indicates if there's an explicit value set for the specified attribute. This can be
+	 * useful in cases where we want to determine if a value has been explicitly set, as opposed
+	 * to a wrapper method that is returning a default value that has been provided for an attribute.
+	 * @param ai the attribute info definition.
+	 * @return true if there's a value and false otherwise
+	 */
+	public boolean hasValue(DmcAttributeInfo ai){
+		synchronized (attributes) {
+			DmcAttribute<?> rc = attributes.get(ai.id);
+			if (rc == null)
+				return(false);
+			
+			return(true);
+		}
+	}
+	
+	/**
 	 * Retrieves the names of attributes in this object. If you only want the single
 	 * valued attributes.
 	 * @param onlySV  if true, will only return single valued attribute names.

--- a/src/org/dmd/dmc/presentation/DmcPresentationIF.java
+++ b/src/org/dmd/dmc/presentation/DmcPresentationIF.java
@@ -105,6 +105,14 @@ public interface DmcPresentationIF {
 	public void resetToExisting();
 	
 	/**
+	 * This methods allows you to set the presentation to be empty. This may be used by
+	 * higher level logic associated with a form that needs to remove values from some
+	 * fields due to the state of another field. The implementation should alter the
+	 * associated value adapter to be empty.
+	 */
+	public void setEmpty();
+	
+	/**
 	 * This aspect is more tricky than it might first appear. Although the adapter has a
 	 * valueChanged() method on it that could be used by a DmcPresentationTrackerIF component,
 	 * that method can't take into account changes in the presentation state that are 

--- a/src/org/dmd/dms/util/DmoActionFormatter.java
+++ b/src/org/dmd/dms/util/DmoActionFormatter.java
@@ -185,7 +185,7 @@ public class DmoActionFormatter {
       		while(it.hasNext()) {
       			AttributeDefinition attr = it.next();
       			
-          		out.write("        if (get(\"" + attr.getDMSAGReference() + "\") == null){\n");
+          		out.write("        if (get(" + attr.getDMSAGReference() + ") == null){\n");
           		out.write("            if (ex == null)\n");
           		out.write("                ex = new DmcValueExceptionSet();\n");
           		out.write("            ex.add(new DmcValueException(\"" + cappedName + "ATI - missing mandatory parameter: " + attr.getName() + "\"));\n");

--- a/src/org/dmd/dmt/shared/generated/dmo/TestActionATI.java
+++ b/src/org/dmd/dmt/shared/generated/dmo/TestActionATI.java
@@ -350,12 +350,12 @@ public class TestActionATI extends ActionTriggerInfo implements Serializable {
     public void checkParams() throws DmcValueExceptionSet {
         DmcValueExceptionSet ex = null;
 
-        if (get("DmtDMSAG.__svBoolean") == null){
+        if (get(DmtDMSAG.__svBoolean) == null){
             if (ex == null)
                 ex = new DmcValueExceptionSet();
             ex.add(new DmcValueException("TestActionATI - missing mandatory parameter: svBoolean"));
         }
-        if (get("DmtDMSAG.__svTestBasicNamedObjectFixed") == null){
+        if (get(DmtDMSAG.__svTestBasicNamedObjectFixed) == null){
             if (ex == null)
                 ex = new DmcValueExceptionSet();
             ex.add(new DmcValueException("TestActionATI - missing mandatory parameter: svTestBasicNamedObjectFixed"));


### PR DESCRIPTION
Method to determine if a DmcObject has a value for a particular
attribute.

Added to setEmpty() to the presentation interface so that fields can be
wiped - this allows for higher level logic around the form to clear
fields on the basis of values in other fields.