### PR TITLE
Allow quoted parts of complex types to be blank strings.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Name: dark-matter-data
 Specification-Title: dark-matter-data
-Specification-Version: 3.1.4
+Specification-Version: 3.1.5
 Specification-Vendor: dark-matter-data committers
 Implementation-Title: org.dmd
 Implementation-Version: 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.connectifex</groupId>
   <artifactId>dark-matter-data</artifactId>
-  <version>3.1.4</version>
+  <version>3.1.5</version>
   
   <!-- Even though the gwteventservice 1.1.1 dependency should be available from mvnrepository.com
   the dependency inclusion fails for some reason. It indicates that this is where the dependency

--- a/src/org/dmd/dmc/util/ComplexTypeSplitter.java
+++ b/src/org/dmd/dmc/util/ComplexTypeSplitter.java
@@ -107,9 +107,11 @@ public class ComplexTypeSplitter {
 			if (input.charAt(i) == '"'){
 				String quotedPart = input.substring(position.intValue() + 1, i);
 				
-				// It's possible that we have nothing in the quotes, in which case the value would be null
+				// It's possible that we have nothing in the quotes, in which case the value would be
+				// an empty string. Originally, this had provided null as the value, but, since this
+				// is a quoted value, an empty string makes more sense.
 				if (quotedPart.length() == 0)
-					quotedPart = null;
+					quotedPart = "";
 				
 				rc = new ParsedNameValuePair(namePart, quotedPart);
 				position.set(i);

--- a/src/org/dmd/util/parsing/DmcUncheckedOIFParser.java
+++ b/src/org/dmd/util/parsing/DmcUncheckedOIFParser.java
@@ -250,7 +250,7 @@ public class DmcUncheckedOIFParser {
                             }
 
                             try{
-                            	handler.handleObject(uco,fn, in.getLineNumber());
+                            	handler.handleObject(uco,fn, uco.lineNumber);
                             }
                             catch(ResultException ex){
 //                            	DebugInfo.debug(ex.toString());
@@ -326,7 +326,7 @@ public class DmcUncheckedOIFParser {
             }
 
             try{
-            	handler.handleObject(uco,fn,lastLine);
+            	handler.handleObject(uco,fn,uco.lineNumber);
             }
             catch(ResultException ex){
 //            	DebugInfo.debug(ex.toString());

--- a/test/org/dmd/dmc/util/ComplexTypeSplitterTest.java
+++ b/test/org/dmd/dmc/util/ComplexTypeSplitterTest.java
@@ -112,7 +112,7 @@ public class ComplexTypeSplitterTest {
 		assertEquals("Third value name should be version", "version", rc.get(2).name);
 		assertEquals("Third value should be 1.1.2.3", "1.1.2.3", rc.get(2).value);
 		assertEquals("Fourth value name should be comment", "comment", rc.get(3).name);
-		assertEquals("Fourth value should be null", null, rc.get(3).value);
+		assertEquals("Fourth value should be empty string", "", rc.get(3).value);
 		
 		rc = ComplexTypeSplitter.parse("   Integer tag version=1.1.2.3 	\t	comment=\"this 	is cool!\"");
 		


### PR DESCRIPTION
Fixed the OIF parser to report the line number of an object to be the
first line of the object.