### PR TITLE
Code generation tweak.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.connectifex</groupId>
   <artifactId>dark-matter-data</artifactId>
-  <version>3.1.8</version>
+  <version>3.1.9</version>
   
   <!-- Even though the gwteventservice 1.1.1 dependency should be available from mvnrepository.com
   the dependency inclusion fails for some reason. It indicates that this is where the dependency

--- a/src/org/dmd/dms/util/GenUtility.java
+++ b/src/org/dmd/dms/util/GenUtility.java
@@ -3325,7 +3325,7 @@ public class GenUtility {
       		            	
   		out.write("    @Override\n");
 		out.write("    // Generated from: " + DebugInfo.getWhereWeAreNow() + "\n");
-  		out.write("    protected void formatValueAsJSON(StringBuffer sb, int padding, String indent) {\n");
+  		out.write("    public void formatValueAsJSON(StringBuffer sb, int padding, String indent) {\n");
   		out.write("        if (getMVSize() == 0){\n");
   		out.write("            getSV().toJSON(sb,padding,indent);\n");
   		out.write("        }\n");
@@ -3341,7 +3341,7 @@ public class GenUtility {
   		out.write("    }\n\n");
 
   		out.write("    // Generated from: " + DebugInfo.getWhereWeAreNow() + "\n");
-  		out.write("    protected " + cn + " typeCheck(Object value) throws DmcValueException {\n");
+  		out.write("    public " + cn + " typeCheck(Object value) throws DmcValueException {\n");
   		out.write("        " + cn + " rc = null;\n\n");
   		
   		out.write("        if (value instanceof " + cn + "){\n");


### PR DESCRIPTION
The generated DmcType<>STATIC class had a protected typeCheck() method
that needed to be public. Found while adding a manually tweaked,
generated class as a new defined type.